### PR TITLE
Adjust method signatures to match parent

### DIFF
--- a/syntax.php
+++ b/syntax.php
@@ -38,7 +38,7 @@ class syntax_plugin_googletrends extends DokuWiki_Syntax_Plugin {
     }
 
 
-    public function handle($match, $state, $pos, &$handler){
+    public function handle($match, $state, $pos, Doku_Handler $handler){
 		$match = explode("|", preg_replace("/^.*?>(.*)}}$/", "$1", $match));
 		// terms
 		$terms = preg_replace("/[^,a-zA-Z0-9 +]/", "", $match[0]);
@@ -55,7 +55,7 @@ class syntax_plugin_googletrends extends DokuWiki_Syntax_Plugin {
         return $data;
     }
 
-    public function render($mode, &$renderer, $data) {
+    public function render($mode, Doku_Renderer $renderer, $data) {
         if($mode != 'xhtml') return false;
             $renderer->doc .= '<script type="text/javascript" src="//www.google.com/trends/embed.js?'
 				.'hl='.$data["hl"]


### PR DESCRIPTION
Starting with PHP 7, classes that overide methods from their parent have to match their parent's method signature regarding type hints. Otherwise PHP will throw an error.

Your plugin seems not to match DokuWiki's method signatures causing it to fail under PHP7. This patch tries to fix that.

Please note that this patch and the resulting pull request were created using an automated tool. Something might have gone, wrong so please carefully check before merging.

If you think the code submitted is wrong, please feel free to close this PR and excuse the mess.
